### PR TITLE
Removed text-selecting functionality on buttons for all browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,11 +68,11 @@
 		</div>
 
 		<!--Div to create buttons to click-->
-		<div id = 'lightButton' class = 'lightButton'>
+		<div id = 'lightButton' class = 'lightButton noselect'>
 	      Click to turn on the Lights!
 	  </div>
 
-	  <div id = 'resetButton' class = 'resetButton'>
+	  <div id = 'resetButton' class = 'resetButton noselect'>
 	  	Reset
 	  </div>
 
@@ -82,6 +82,7 @@
 	  		<li><a href="https://www.codeacademy.com" target="_blank">Code Academy</a></li>
 	  		<li><a href="https://codetheweb.blog/style-a-navigation-bar-css/" target = "_blank">Code The Web</a></li>
 	  		<li><a href="https://www.w3schools.com/howto/howto_css_fixed_footer.asp" target = "_blank">W3 Schools</a></li>
+	  		<li><a href = "https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting">Disable text select</a></li>
 	  	</ul>
 	  </footer>
 

--- a/style.css
+++ b/style.css
@@ -132,6 +132,23 @@ header li a:hover{
 	box-shadow: 2px 2px 3px 1px black;
 }
 
+/** This code is taken from Stack Overflow to prevent users
+from being able to select text on any website.  Link to code is
+below as well as on the footer of the page 
+
+https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting 
+
+**/
+.noselect {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Old versions of Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Edge, Opera and Firefox */
+}
+
 /**Footer code**/
 footer{
 	position:absolute;


### PR DESCRIPTION
Took some code from stack overflow (link included in footer) that prevents text-selection when using the ```.noselect``` class.